### PR TITLE
ch-add-system-variable-to-dotenv-webpack

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ module.exports =[{
     }),
     new dotenv({
       path: path.resolve(__dirname, `./.env`),
+      systemvars: true
     }),
     new TerserPlugin(),
   ],


### PR DESCRIPTION
### What does this PR do:
- Configured dotenv-webpack to get also systemvars
- This solves missing environment variables needed by our app